### PR TITLE
Bifurcate read-seek functionality

### DIFF
--- a/header.go
+++ b/header.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
-	"time"
 )
 
 // Entry represents an libarchive archive_entry
@@ -68,9 +67,6 @@ func (e *entryInfo) Mode() os.FileMode {
 		mode |= os.ModeNamedPipe
 	}
 	return mode
-}
-func (e *entryInfo) ModTime() time.Time {
-	return time.Unix(int64(e.stat.st_mtim.tv_sec), int64(e.stat.st_mtim.tv_nsec))
 }
 func (e *entryInfo) IsDir() bool {
 	return e.stat.st_mode&syscall.S_IFDIR != 0

--- a/header_darwin.go
+++ b/header_darwin.go
@@ -1,0 +1,14 @@
+package archive
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"time"
+)
+
+func (e *entryInfo) ModTime() time.Time {
+	return time.Unix(int64(e.stat.st_mtimespec.tv_sec), int64(e.stat.st_mtimespec.tv_nsec))
+}

--- a/header_linux.go
+++ b/header_linux.go
@@ -1,0 +1,14 @@
+package archive
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"time"
+)
+
+func (e *entryInfo) ModTime() time.Time {
+	return time.Unix(int64(e.stat.st_mtim.tv_sec), int64(e.stat.st_mtim.tv_nsec))
+}

--- a/readseeker.go
+++ b/readseeker.go
@@ -1,0 +1,152 @@
+package archive
+
+/*
+#cgo pkg-config: libarchive
+#include <archive.h>
+#include <archive_entry.h>
+#include <stdlib.h>
+#include "reader.h"
+*/
+import "C"
+import (
+	"errors"
+	"io"
+	"sync"
+	"unsafe"
+)
+
+var readSeekers = make(map[uint64]*ReadSeeker)
+
+var readSeekerIndex uint64
+
+var readSeekerLock sync.Mutex
+
+// ReadSeeker represents libarchive archive
+type ReadSeeker struct {
+	archive *C.struct_archive
+	reader  io.ReadSeeker // the io.ReadSeeker from which we Read
+	buffer  []byte        // buffer for the raw reading
+	offset  int64         // current reading offset
+	index   *uint64       // lookup index
+}
+
+// NewReadSeeker returns new Archive by calling archive_read_open
+func NewReadSeeker(reader io.ReadSeeker) (r *ReadSeeker, err error) {
+	r = new(ReadSeeker)
+
+	readSeekerLock.Lock()
+	r.index = new(uint64)
+	*r.index = readSeekerIndex
+	readSeekers[readSeekerIndex] = r
+	readSeekerIndex++
+	readSeekerLock.Unlock()
+
+	r.buffer = make([]byte, 1024)
+	r.archive = C.archive_read_new()
+	C.archive_read_support_filter_all(r.archive)
+	C.archive_read_support_format_all(r.archive)
+
+	seekCb := (*C.archive_seek_callback)(C.go_libarchive_seek)
+	C.archive_read_set_seek_callback(r.archive, seekCb)
+
+	r.reader = reader
+
+	e := C.go_libarchive_open(r.archive, unsafe.Pointer(r.index))
+
+	err = codeToError(r.archive, int(e))
+	return
+}
+
+//export myseek
+func myseek(_ *C.struct_archive, clientData unsafe.Pointer, request C.int64_t, whence C.int) C.int64_t {
+	readSeekerLock.Lock()
+	index := *(*uint64)(clientData)
+	reader := readSeekers[index]
+	readSeekerLock.Unlock()
+
+	offset, err := reader.reader.Seek(int64(request), int(whence))
+	if err != nil {
+		return C.int64_t(0)
+	}
+	return C.int64_t(offset)
+}
+
+// Next calls archive_read_next_header and returns an
+// interpretation of the Entry which is a wrapper around
+// libarchive's archive_entry, or Err.
+//
+// ErrArchiveEOF is returned when there
+// is no more to be read from the archive
+func (r *ReadSeeker) Next() (Entry, error) {
+	e := new(entryImpl)
+
+	errno := int(C.archive_read_next_header(r.archive, &e.entry))
+	err := codeToError(r.archive, errno)
+
+	if err != nil {
+		e = nil
+	}
+
+	return e, err
+}
+
+// Read calls archive_read_data which reads the current archive_entry.
+// It acts as io.ReadSeeker.Read in any other aspect
+func (r *ReadSeeker) Read(b []byte) (n int, err error) {
+	n = int(C.archive_read_data(r.archive, unsafe.Pointer(&b[0]), C.size_t(cap(b))))
+	if n == 0 {
+		err = ErrArchiveEOF
+	} else if 0 > n { // err
+		err = codeToError(r.archive, C.ARCHIVE_FAILED)
+		n = 0
+	}
+	r.offset += int64(n)
+	return
+}
+
+// Seek sets the offset for the next Read to offset
+func (r *ReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case 0:
+		abs = offset
+	case 1:
+		abs = r.offset + offset
+	case 2:
+		abs = int64(len(r.buffer)) + offset
+	default:
+		return 0, errors.New("libarchive: SEEK [invalid whence]")
+	}
+	if abs < 0 {
+		return 0, errors.New("libarchive: SEEK [negative position]")
+	}
+	r.offset = abs
+	return abs, nil
+}
+
+// Size returns compressed size of the current archive entry
+func (r *ReadSeeker) Size() int {
+	return int(C.archive_filter_bytes(r.archive, C.int(0)))
+}
+
+// Free frees the resources the underlying libarchive archive is using
+// calling archive_read_free
+func (r *ReadSeeker) Free() error {
+	readSeekerLock.Lock()
+	delete(readSeekers, *r.index)
+	readSeekerLock.Unlock()
+
+	if C.archive_read_free(r.archive) == C.ARCHIVE_FATAL {
+		return ErrArchiveFatal
+	}
+	return nil
+}
+
+// Close closes the underlying libarchive archive
+// calling archive read_cloe
+func (r *ReadSeeker) Close() error {
+	if C.archive_read_close(r.archive) == C.ARCHIVE_FATAL {
+		return ErrArchiveFatal
+	}
+	return nil
+}

--- a/readseeker_bench_test.go
+++ b/readseeker_bench_test.go
@@ -1,0 +1,112 @@
+package archive_test
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ar "github.com/sergeyfedotov/go-libarchive"
+)
+
+type ArchiveReadSeeker interface {
+	io.Reader
+	Next() (interface{}, error)
+}
+
+var buf = make([]byte, 4096) // probably fine
+
+func BenchTestFuncLib(b *testing.B, file io.ReadSeeker) {
+	reader, _ := ar.NewReader(file)
+	defer reader.Free()
+	defer reader.Close()
+	runBenchTest(b, wrapLibArchive(reader))
+}
+
+func BenchTestFuncSTD(b *testing.B, file io.ReadSeeker) {
+	reader := tar.NewReadSeeker(file)
+	runBenchTest(b, wrapTarArchive(reader))
+}
+
+func wrapLibArchive(r *ar.ReadSeeker) ArchiveReadSeeker {
+	return &libArchiveReaderWrapper{reader: r}
+}
+
+func wrapTarArchive(r *tar.Reader) ArchiveReader {
+	return &libStdlibTarReaderWrapper{reader: r}
+}
+
+type libArchiveReaderWrapper struct {
+	reader *ar.Reader
+}
+
+func (l *libArchiveReaderWrapper) Read(b []byte) (int, error) {
+	return l.reader.Read(b)
+}
+
+func (l *libArchiveReaderWrapper) Next() (interface{}, error) {
+	return l.reader.Next()
+}
+
+type libStdlibTarReaderWrapper struct {
+	reader *tar.Reader
+}
+
+func (l *libStdlibTarReaderWrapper) Read(b []byte) (int, error) {
+	return l.reader.Read(b)
+}
+
+func (l *libStdlibTarReaderWrapper) Next() (interface{}, error) {
+	return l.reader.Next()
+}
+
+func runBenchTest(b *testing.B, a ArchiveReader) {
+	totalBytesRead := new(int)
+	defer func(t *int) {
+		b.SetBytes(int64(*t))
+	}(totalBytesRead)
+
+	for {
+		_, err := a.Next()
+		if err != nil {
+			return
+		}
+
+		var bytesread int
+		for ; err == nil; bytesread, err = a.Read(buf) {
+			*totalBytesRead += bytesread
+
+		}
+	}
+}
+
+func benchTemplate(b *testing.B, testFunc func(b *testing.B, file io.ReadSeeker)) {
+	matches, err := filepath.Glob("./fixtures/bench[0-9]*.tar")
+	if err != nil {
+		b.Skipf("Error while getting benchmark fixtures:\n%s", err)
+	}
+	if len(matches) == 0 {
+		b.Skip("No benchmark fixtures found!\nPut them in './fixtures/' with names like bench1.tar bench2.tar ...")
+	}
+	for _, match := range matches {
+		b.StopTimer()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			file, _ := os.Open(match)
+			b.StartTimer()
+			testFunc(b, file)
+			b.StopTimer()
+			file.Close()
+		}
+		b.StopTimer()
+	}
+}
+
+func BenchmarkLibArchive(b *testing.B) {
+	benchTemplate(b, BenchTestFuncLib)
+}
+
+func BenchmarkSTDArchive(b *testing.B) {
+	benchTemplate(b, BenchTestFuncSTD)
+}

--- a/readseeker_test.go
+++ b/readseeker_test.go
@@ -1,0 +1,80 @@
+package archive
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestNewReadSeeker(t *testing.T) {
+	testFile, err := os.Open("./fixtures/test.tar")
+	if err != nil {
+		t.Fatalf("Error while reading fixture file %s ", err)
+	}
+
+	reader, err := NewReadSeeker(testFile)
+	if err != nil {
+		t.Fatalf("Error on creating Archive from a io.ReadSeeker:\n %s", err)
+	}
+	defer func() {
+		err := reader.Free()
+
+		if err != nil {
+			t.Fatalf("Error on reader Free:\n %s", err)
+		}
+	}()
+
+	defer func() {
+		err := reader.Close()
+		if err != nil {
+			t.Fatalf("Error on reader Close:\n %s", err)
+		}
+	}()
+	entry, err := reader.Next()
+	if err != nil {
+		t.Fatalf("got error on reader.Next():\n%s", err)
+	}
+	name := entry.PathName()
+	if name != "a" {
+		t.Fatalf("got %s expected %s as Name of the first entry", name, "a")
+	}
+
+	b := make([]byte, 512)
+	size, err := reader.Read(b)
+	if err != nil {
+		t.Fatalf("got error on reader.Read():\n%s", err)
+	}
+	if size != 14 {
+		t.Fatalf("got %d as size of the read but expected %d", size, 14)
+	}
+
+	expectedContent := []byte("Sha lalal lal\n")
+	if !bytes.Equal((b[:size]), expectedContent) {
+		t.Fatalf("The contents:\n [%s] are not the expectedContent:\n [%s]", b[:size], expectedContent)
+	}
+
+	_, err = reader.Next()
+	if err != ErrArchiveEOF {
+		t.Fatalf("Expected EOF on second reader.Next() got err :\n %s", err)
+	}
+}
+
+func TestTwoReadSeekers(t *testing.T) {
+	testFile, err := os.Open("./fixtures/test.tar")
+	if err != nil {
+		t.Fatalf("Error while reading fixture file %s ", err)
+	}
+
+	_, err = NewReadSeeker(testFile)
+
+	testFile2, err := os.Open("./fixtures/test2.tar")
+	if err != nil {
+		t.Fatalf("Error while reading fixture file %s ", err)
+	}
+
+	_, err = NewReadSeeker(testFile2)
+	if err != nil {
+		t.Fatalf("Error on creating Archive from a io.ReadSeeker:\n %s", err)
+	}
+
+}


### PR DESCRIPTION
This is a forward-port of the Reader/ReadSeeker patches I submitted to your upstream, mstoykov.

What this does is return the ability to handle streamed archives, which is libarchive's main mode of operation, while retaining the ReadSeeker pieces necessary for 7z and other formats that need to perform random IO.